### PR TITLE
reassorted hero.enums.ts, making it better for random choosing

### DIFF
--- a/models/transient/hero.enums.ts
+++ b/models/transient/hero.enums.ts
@@ -1,6 +1,5 @@
 export enum EHeroEnum {
   NO_HERO,
-  RANDOM,
   ACE,
   AEMON,
   BANDITO,
@@ -37,11 +36,11 @@ export enum EHeroEnum {
   VERMILLION,
   VEX,
   ZAKU,
+  RANDOM,
 }
 
 export const HeroEnumText = new Map<EHeroEnum, string>()
 .set(EHeroEnum.NO_HERO, 'No hero selected')
-.set(EHeroEnum.RANDOM, 'Random')
 .set(EHeroEnum.ACE, 'Ace')
 .set(EHeroEnum.AEMON, 'Aemon')
 .set(EHeroEnum.BANDITO, 'Bandito')
@@ -77,7 +76,8 @@ export const HeroEnumText = new Map<EHeroEnum, string>()
   .set(EHeroEnum.TRIXIE, 'Trixie')
   .set(EHeroEnum.VERMILLION, 'Vermillion')
   .set(EHeroEnum.VEX, 'Vex')
-  .set(EHeroEnum.ZAKU, 'Zaku');
+  .set(EHeroEnum.ZAKU, 'Zaku')
+  .set(EHeroEnum.RANDOM, 'Random');
 
 export const HeroEnumGameName = new Map<EHeroEnum, string>()
   .set(EHeroEnum.ACE, 'Hero_Ace')


### PR DESCRIPTION
I just put random hero to the end of the list for several reasons:
- It put random button to the end of the hero list, where she belongs better, than at the start (arguable);
- Now it marks the end of the list. Which will allow to get an amount of heroes available. With it even if you add heroes to the list or remove them, any function, that requires amount of heroes available won't require an update.

This change has to be applied with the change I made for ce-client.